### PR TITLE
Controller rest request body

### DIFF
--- a/lib/Horde/Controller/Request.php
+++ b/lib/Horde/Controller/Request.php
@@ -57,4 +57,11 @@ interface Horde_Controller_Request
     /**
      */
     public function getSessionId();
+
+    /**
+     * The request body if it is not form-encoded
+     * @returns Horde_Stream
+     */
+    public function getRequestBody();
+    
 }

--- a/lib/Horde/Controller/Request/Http.php
+++ b/lib/Horde/Controller/Request/Http.php
@@ -70,6 +70,15 @@ class Horde_Controller_Request_Http implements Horde_Controller_Request
         return $_POST;
     }
 
+    /**
+     * The request body if it is not form-encoded
+     * @returns Horde_Stream
+     */
+    public function getRequestBody()
+    {
+        return new Horde_Stream_Existing(array('stream' => 'php://input'));
+    }    
+
     public function getCookieVars()
     {
         return $_COOKIE;

--- a/lib/Horde/Controller/Request/Mock.php
+++ b/lib/Horde/Controller/Request/Mock.php
@@ -105,6 +105,6 @@ class Horde_Controller_Request_Mock extends Horde_Controller_Request_Http
      */
     public function getRequestBody()
     {
-        return new Horde_Stream_String(array('string' => $this->getVars('REQUEST'));
+        return new Horde_Stream_String(array('string' => $this->getVars('REQUEST')));
     }
 }

--- a/lib/Horde/Controller/Request/Mock.php
+++ b/lib/Horde/Controller/Request/Mock.php
@@ -98,4 +98,13 @@ class Horde_Controller_Request_Mock extends Horde_Controller_Request_Http
     {
         return $this->getVars('REQUEST');
     }
+    
+    /**
+     * The request body if it is not form-encoded
+     * @returns Horde_Stream
+     */
+    public function getRequestBody()
+    {
+        return new Horde_Stream_String(array('string' => $this->getVars('REQUEST'));
+    }
 }

--- a/lib/Horde/Controller/Request/Null.php
+++ b/lib/Horde/Controller/Request/Null.php
@@ -83,4 +83,13 @@ class Horde_Controller_Request_Null implements Horde_Controller_Request
     public function getSessionId()
     {
     }
+    
+    /**
+     * The request body if it is not form-encoded
+     * @returns Horde_Stream
+     */
+    public function getRequestBody()
+    {
+    }
+    
 }


### PR DESCRIPTION
 Add Request Body Stream to interface

I noticed Horde_Controller currently lacks any access to the body of a http request like post or put, unless it's form-encoded. In this case, getPostVars works well
For the REST usecase, I would want to post/put a json object string containing details.

Another use case would be handling some bulk upload like a file (owncloudish) or a media stream.

For the REST use case, just slurping stdin and returning it as a string would be sufficient.
For the latter, it would be more convenient to expose the stream resource - both memory and performance wise.
Horde_Stream has a __toString() to implicitly return a string where one is expected.